### PR TITLE
Retry lora ack

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -15,6 +15,7 @@ extern EventType g_EventType;
 extern uint8_t g_rcvdLoRaData[];
 extern uint8_t g_rcvdDataLen;
 extern bool g_lorawan_joined;
+extern bool g_lorawan_msgconfirmed;
 
 void initMotionSensor();
 

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,2 @@
+#pragma once
+#define VERSIONSTRING "5262b0d1a47ad9994d37b18129f03c8fe629c1a4"

--- a/src/lorahelper.cpp
+++ b/src/lorahelper.cpp
@@ -31,7 +31,8 @@ void LoraHelper::lorawan_unconf_finished(void)
 
 void LoraHelper::lorawan_conf_finished(bool result)
 {
-    SERIAL_LOG("Confirmed TX %s\n", result ? "success" : "failed");
+    SERIAL_LOG("Confirmed TX %s", result ? "success" : "failed");
+    g_lorawan_msgconfirmed = result;
 }
 
 void LoraHelper::lorawan_join_failed_handler(void)


### PR DESCRIPTION
This adds a little retry logic if we have acknowledgement enabled.

The complexity here is that the lora subsystem just does it's thing and that there's only a failed status from `lmh_send()` whenever it's busy, or other things. NOT when there's no confirmation.
So, we had to add a global variable and loop to check confirmation.